### PR TITLE
refactor: 게시글 제목 2줄이상 ...으로 처리, 모든 좋아요 기능에 낙관적 업데이트 적용

### DIFF
--- a/src/apis/post/index.ts
+++ b/src/apis/post/index.ts
@@ -4,7 +4,7 @@ import { AxiosError } from "axios";
 import postLikes from "@/components/common/Post/apis/postLikes";
 import openToast from "@/components/common/Toast/features/openToast";
 import { ErrorResponse } from "@/types/error";
-import { PostType } from "@/types/post";
+import { PostDetailType, PostType } from "@/types/post";
 
 interface UseLikeMutationProps {
   id: number;
@@ -29,6 +29,34 @@ export const useLikeMutation = ({ id, queryKey }: UseLikeMutationProps) => {
           response.content.map((item) => {
             item.id === id ? { ...item, isLiked: !item.isLiked } : item;
           });
+        });
+        return { previousTodos };
+      }
+    },
+    onError: (error: AxiosError<ErrorResponse>, newTodo, context) => {
+      queryClient.setQueryData(queryKey, context?.previousTodos);
+      error.response?.status === 401
+        ? openToast("warn", "로그인이 필요한 서비스입니다.")
+        : openToast("warn", "에러가 발생하였습니다.");
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey });
+    },
+  });
+};
+
+export const usePostDetailLikeMutation = ({ id, queryKey }: UseLikeMutationProps) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => postLikes(id),
+    onMutate: async () => {
+      if (localStorage.getItem("accessToken")) {
+        await queryClient.cancelQueries({ queryKey });
+
+        const previousTodos = queryClient.getQueryData(queryKey);
+
+        queryClient.setQueryData(queryKey, (response: PostDetailType) => {
+          return { ...response, post: { ...response.post, isLiked: !response.post.isLiked } };
         });
         return { previousTodos };
       }

--- a/src/apis/post/index.ts
+++ b/src/apis/post/index.ts
@@ -25,11 +25,11 @@ export const useLikeMutation = ({ id, queryKey }: UseLikeMutationProps) => {
 
         const previousTodos = queryClient.getQueryData(queryKey);
 
-        queryClient.setQueryData(queryKey, (response: QueryData) => {
-          response.content.map((item) => {
-            item.id === id ? { ...item, isLiked: !item.isLiked } : item;
-          });
-        });
+        queryClient.setQueryData(queryKey, (response: QueryData) => ({
+          ...response,
+          content: response.content.map((item) => (item.id === id ? { ...item, isLiked: !item.isLiked } : item)),
+        }));
+
         return { previousTodos };
       }
     },
@@ -55,9 +55,11 @@ export const usePostDetailLikeMutation = ({ id, queryKey }: UseLikeMutationProps
 
         const previousTodos = queryClient.getQueryData(queryKey);
 
-        queryClient.setQueryData(queryKey, (response: PostDetailType) => {
-          return { ...response, post: { ...response.post, isLiked: !response.post.isLiked } };
-        });
+        queryClient.setQueryData(queryKey, (response: PostDetailType) => ({
+          ...response,
+          post: { ...response.post, isLiked: !response.post.isLiked },
+        }));
+
         return { previousTodos };
       }
     },

--- a/src/components/common/Post/Post.module.scss
+++ b/src/components/common/Post/Post.module.scss
@@ -125,9 +125,3 @@
   z-index: 1;
   @include nsnFont(2rem, 900, normal);
 }
-
-.heart {
-  position: absolute;
-  top: 1rem;
-  right: 2rem;
-}

--- a/src/components/common/Post/Post.module.scss
+++ b/src/components/common/Post/Post.module.scss
@@ -63,12 +63,11 @@
 
 .title {
   @include font(2rem, 700, normal);
-  @include line-clamp(2);
+  @include line-clamp(1);
+}
+
+.hr {
   border-bottom: 0.1rem solid #ccc;
-  padding-bottom: 2rem;
-  @include smallDesktop {
-    @include nsnFont(2rem, 700, normal);
-  }
 }
 
 .detailBox {

--- a/src/components/common/Post/Post.tsx
+++ b/src/components/common/Post/Post.tsx
@@ -57,6 +57,7 @@ export function Post({ data, children }: PostProps) {
         <div className={cn("contentBox")}>
           <div className={cn("box")}>
             <p className={cn("title")}>{title}</p>
+            <div className={cn("hr")} />
             <div className={cn("detailBox")}>
               <div className={cn("districtBox")}>
                 <Location />

--- a/src/components/common/Post/Post.tsx
+++ b/src/components/common/Post/Post.tsx
@@ -1,17 +1,12 @@
-import { MouseEvent } from "react";
-
 import classNames from "classnames/bind";
 
 import Link from "next/link";
 
-import { useLikeMutation } from "@/apis/post";
 import styles from "@/components/common/Post/Post.module.scss";
 import { ROUTE } from "@/constants/route";
 import Calendar from "@/icons/calendar.svg";
 import Clock from "@/icons/clock.svg";
-import Heart from "@/icons/heart.svg";
 import Location from "@/icons/location.svg";
-import PinkHeart from "@/icons/pink_heart.svg";
 import { PostType } from "@/types/post";
 import { formatDateString } from "@/utils";
 
@@ -83,30 +78,5 @@ export function Post({ data, children }: PostProps) {
         {disabilityType !== "없음" && <PostLabel text={disabilityType} />}
       </div>
     </Link>
-  );
-}
-
-interface PostHeartProps {
-  id: number;
-  isLiked: boolean;
-  queryKey: string[];
-}
-
-export function PostHeart({ id, isLiked, queryKey }: PostHeartProps) {
-  const { mutate } = useLikeMutation({ id, queryKey });
-
-  const handleHeartClick = (event: MouseEvent<SVGSVGElement>) => {
-    event.preventDefault();
-    mutate();
-  };
-
-  return (
-    <>
-      {isLiked ? (
-        <PinkHeart onClick={handleHeartClick} width={32} height={32} className={cn("heart")} />
-      ) : (
-        <Heart onClick={handleHeartClick} width={32} height={32} className={cn("heart")} />
-      )}
-    </>
   );
 }

--- a/src/components/common/Post/PostHeart/PostHeart.tsx
+++ b/src/components/common/Post/PostHeart/PostHeart.tsx
@@ -14,37 +14,37 @@ interface PostHeartProps {
 export function PostHeart({ id, isLiked, queryKey, style }: PostHeartProps) {
   const { mutate } = useLikeMutation({ id, queryKey });
 
-  const handleHeartClick = (event: MouseEvent<SVGSVGElement>) => {
+  const handleHeartClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     mutate();
   };
 
   return (
-    <>
+    <button onClick={handleHeartClick}>
       {isLiked ? (
-        <PinkHeart onClick={handleHeartClick} width={32} height={32} className={style} />
+        <PinkHeart width={32} height={32} className={style} />
       ) : (
-        <Heart onClick={handleHeartClick} width={32} height={32} className={style} />
+        <Heart width={32} height={32} className={style} />
       )}
-    </>
+    </button>
   );
 }
 
 export function PostDetailHeart({ id, isLiked, queryKey, style }: PostHeartProps) {
   const { mutate } = usePostDetailLikeMutation({ id, queryKey });
 
-  const handleHeartClick = (event: MouseEvent<SVGSVGElement>) => {
+  const handleHeartClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     mutate();
   };
 
   return (
-    <>
+    <button onClick={handleHeartClick}>
       {isLiked ? (
-        <PinkHeart onClick={handleHeartClick} width={32} height={32} className={style} />
+        <PinkHeart width={32} height={32} className={style} />
       ) : (
-        <Heart onClick={handleHeartClick} width={32} height={32} className={style} />
+        <Heart width={32} height={32} className={style} />
       )}
-    </>
+    </button>
   );
 }

--- a/src/components/common/Post/PostHeart/PostHeart.tsx
+++ b/src/components/common/Post/PostHeart/PostHeart.tsx
@@ -1,0 +1,50 @@
+import { MouseEvent } from "react";
+
+import { useLikeMutation, usePostDetailLikeMutation } from "@/apis/post";
+import Heart from "@/icons/heart.svg";
+import PinkHeart from "@/icons/pink_heart.svg";
+
+interface PostHeartProps {
+  id: number;
+  isLiked: boolean;
+  queryKey: string[];
+  style: string;
+}
+
+export function PostHeart({ id, isLiked, queryKey, style }: PostHeartProps) {
+  const { mutate } = useLikeMutation({ id, queryKey });
+
+  const handleHeartClick = (event: MouseEvent<SVGSVGElement>) => {
+    event.preventDefault();
+    mutate();
+  };
+
+  return (
+    <>
+      {isLiked ? (
+        <PinkHeart onClick={handleHeartClick} width={32} height={32} className={style} />
+      ) : (
+        <Heart onClick={handleHeartClick} width={32} height={32} className={style} />
+      )}
+    </>
+  );
+}
+
+export function PostDetailHeart({ id, isLiked, queryKey, style }: PostHeartProps) {
+  const { mutate } = usePostDetailLikeMutation({ id, queryKey });
+
+  const handleHeartClick = (event: MouseEvent<SVGSVGElement>) => {
+    event.preventDefault();
+    mutate();
+  };
+
+  return (
+    <>
+      {isLiked ? (
+        <PinkHeart onClick={handleHeartClick} width={32} height={32} className={style} />
+      ) : (
+        <Heart onClick={handleHeartClick} width={32} height={32} className={style} />
+      )}
+    </>
+  );
+}

--- a/src/components/page-layout/HomeLayout/components/PostList/GiverPostList/GiverPostList.module.scss
+++ b/src/components/page-layout/HomeLayout/components/PostList/GiverPostList/GiverPostList.module.scss
@@ -15,3 +15,9 @@
   grid-template-columns: repeat(4, 1fr);
   gap: 3rem;
 }
+
+.heart {
+  position: absolute;
+  top: 1rem;
+  right: 2rem;
+}

--- a/src/components/page-layout/HomeLayout/components/PostList/GiverPostList/GiverPostList.tsx
+++ b/src/components/page-layout/HomeLayout/components/PostList/GiverPostList/GiverPostList.tsx
@@ -3,7 +3,8 @@ import classNames from "classnames/bind";
 
 import Link from "next/link";
 
-import { Post, PostHeart } from "@/components/common/Post/Post";
+import { Post } from "@/components/common/Post/Post";
+import { PostHeart } from "@/components/common/Post/PostHeart/PostHeart";
 import styles from "@/components/page-layout/HomeLayout/components/PostList/GiverPostList/GiverPostList.module.scss";
 import { ROUTE } from "@/constants/route";
 import Plus from "@/icons/plus.svg";
@@ -30,7 +31,7 @@ export default function GiverPostList() {
       <div className={cn("postListBox")}>
         {data.content.map((post: PostType) => (
           <Post data={post} key={post.id}>
-            <PostHeart queryKey={["mainHelpYouPostList"]} id={post.id} isLiked={post.isLiked} />
+            <PostHeart queryKey={["mainHelpYouPostList"]} id={post.id} isLiked={post.isLiked} style={cn("heart")} />
           </Post>
         ))}
       </div>

--- a/src/components/page-layout/HomeLayout/components/PostList/TakerPostList/TakerPostList.module.scss
+++ b/src/components/page-layout/HomeLayout/components/PostList/TakerPostList/TakerPostList.module.scss
@@ -15,3 +15,9 @@
   grid-template-columns: repeat(4, 1fr);
   gap: 3rem;
 }
+
+.heart {
+  position: absolute;
+  top: 1rem;
+  right: 2rem;
+}

--- a/src/components/page-layout/HomeLayout/components/PostList/TakerPostList/TakerPostList.tsx
+++ b/src/components/page-layout/HomeLayout/components/PostList/TakerPostList/TakerPostList.tsx
@@ -3,7 +3,8 @@ import classNames from "classnames/bind";
 
 import Link from "next/link";
 
-import { Post, PostHeart } from "@/components/common/Post/Post";
+import { Post } from "@/components/common/Post/Post";
+import { PostHeart } from "@/components/common/Post/PostHeart/PostHeart";
 import styles from "@/components/page-layout/HomeLayout/components/PostList/TakerPostList/TakerPostList.module.scss";
 import { ROUTE } from "@/constants/route";
 import Plus from "@/icons/plus.svg";
@@ -30,7 +31,7 @@ export default function TakerPostList() {
       <div className={cn("postListBox")}>
         {data.content.map((post: PostType) => (
           <Post data={post} key={post.id}>
-            <PostHeart queryKey={["mainHelpMePostList"]} id={post.id} isLiked={post.isLiked} />
+            <PostHeart queryKey={["mainHelpMePostList"]} id={post.id} isLiked={post.isLiked} style={cn("heart")} />
           </Post>
         ))}
       </div>

--- a/src/components/page-layout/helpMeDetailLayout/components/helpMeDetailLayout.module.scss
+++ b/src/components/page-layout/helpMeDetailLayout/components/helpMeDetailLayout.module.scss
@@ -31,7 +31,7 @@
   position: relative;
 }
 
-.likeBtn,
+.heart,
 .kebabBtn,
 .sirenBtn {
   @include flexSort(column, null, center, 0.2rem);

--- a/src/components/page-layout/helpMeDetailLayout/components/helpMeDetailLayout.tsx
+++ b/src/components/page-layout/helpMeDetailLayout/components/helpMeDetailLayout.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import classNames from "classnames/bind";
@@ -12,7 +12,7 @@ import CommentWrite from "@/components/common/commentWrite/commentWrite";
 import getLogIn from "@/components/common/Header/apis/getLogIn";
 import Loader from "@/components/common/Loader/Loader";
 import Modal from "@/components/common/Modal/Modal";
-import postLikes from "@/components/common/Post/apis/postLikes";
+import { PostDetailHeart, PostHeart } from "@/components/common/Post/PostHeart/PostHeart";
 import ReportForm from "@/components/common/ReportForm/ReportForm";
 import openToast from "@/components/common/Toast/features/openToast";
 import styles from "@/components/page-layout/helpMeDetailLayout/components/helpMeDetailLayout.module.scss";
@@ -23,11 +23,9 @@ import { formatDateString } from "@/utils";
 import Arrow from "../../../../../public/icons/arrow_down.svg";
 import Calendar from "../../../../../public/icons/calendar.svg";
 import Clock from "../../../../../public/icons/clock.svg";
-import Heart from "../../../../../public/icons/heart.svg";
 import Kebab from "../../../../../public/icons/kebab.svg";
 import Location from "../../../../../public/icons/location.svg";
 import Person from "../../../../../public/icons/personnel.svg";
-import PinkHeart from "../../../../../public/icons/pink_heart.svg";
 import Siren from "../../../../../public/icons/siren.svg";
 import getAllComment from "../../helpYouDetailLayout/apis/getAllComment";
 import deletePost from "../apis/deletePost";
@@ -52,24 +50,12 @@ export default function HelpMeDetailLayout() {
   const router = useRouter();
   const { id: pageId } = router.query;
 
-  const { data, isPending } = useQuery({
-    queryKey: ["takerDetail", pageId],
-    queryFn: () => getTakerDetail(pageId as string),
-    enabled: !!pageId,
-  });
+  const [isReportOpen, setIsReportOpen] = useState(false);
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [isKebabClick, setIsKebabClick] = useState(false);
+  const [isStateClick, setIsStateClick] = useState(false);
 
-  if (isPending) {
-    return;
-  } else return <Main data={data} />;
-}
-
-function Main(data: any) {
-  const router = useRouter();
-
-  const { id: pageId } = router.query;
-  const queryClient = useQueryClient();
-
-  const { data: userData, isError: userIsError } = useQuery({
+  const { data: userData } = useQuery({
     queryKey: ["userLogIn"],
     queryFn: () => getLogIn(),
   });
@@ -88,10 +74,19 @@ function Main(data: any) {
     enabled: !!pageId,
   });
 
+  const {
+    data: postDetailData,
+    isPending,
+    isError,
+  } = useQuery({
+    queryKey: ["takerPostDetail", `${pageId}`],
+    queryFn: () => getTakerDetail(`${pageId}`),
+    enabled: !!pageId,
+  });
+
   const deletePostMutation = useMutation({
     mutationFn: (id: number) => deletePost(id),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["takerDetail", pageId] });
       router.push(ROUTE.HELP_ME);
       openToast("success", "성공적으로 삭제되었습니다.");
     },
@@ -105,28 +100,17 @@ function Main(data: any) {
     deletePostMutation.mutate(id);
   };
 
-  const { mutate } = useMutation({
-    mutationFn: () => postLikes(id),
-  });
+  if (isPending) return <>...로딩</>;
 
-  const handleHeartClick = () => {
-    setIsHeartClick((prev: boolean) => !prev);
-    mutate();
-  };
+  if (isError) return <>에러</>;
 
-  const { nickname, memberId, disabilityType, gender, profileImageUrl, age } = data.data.author;
+  const { nickname, disabilityType, gender, profileImageUrl, age } = postDetailData.author;
 
-  const { district, id, title, content, createdAt, isLiked, assistance, schedule } = data.data.post;
+  const { district, id, title, content, createdAt, isLiked, assistance, schedule } = postDetailData.post;
 
   const { assistanceType, assistanceStartTime, assistanceEndTime } = assistance;
 
   const { scheduleType, startDate, endDate, scheduleDetails } = schedule;
-
-  const [isReportOpen, setIsReportOpen] = useState(false);
-  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
-  const [isHeartClick, setIsHeartClick] = useState(false);
-  const [isKebabClick, setIsKebabClick] = useState(false);
-  const [isStateClick, setIsStateClick] = useState(false);
 
   const handleKebabClick = () => {
     setIsKebabClick((prev) => !prev);
@@ -137,10 +121,6 @@ function Main(data: any) {
   const handleSirenClick = () => {
     setIsReportOpen(true);
   };
-
-  useEffect(() => {
-    setIsHeartClick(isLiked);
-  }, [data, isLiked]);
 
   const commentMemIds: Array<number> =
     commentData?.pages.flatMap((page) => page.content.map((comment: CommentProps) => comment.author.memberId)) || [];
@@ -154,12 +134,13 @@ function Main(data: any) {
         </header>
         <div className={cn("totalContainer")}>
           <div className={cn("btnMenu")}>
-            {isHeartClick ? (
-              <PinkHeart onClick={handleHeartClick} width={32} height={32} className={cn("likeBtn")} />
-            ) : (
-              <Heart onClick={handleHeartClick} width={32} height={32} className={cn("likeBtn")} />
-            )}
-            {userData?.memberId === data.data.author.memberId ? (
+            <PostDetailHeart
+              style={cn("heart")}
+              id={id}
+              isLiked={isLiked}
+              queryKey={["takerPostDetail", `${pageId}`]}
+            />
+            {userData?.memberId === postDetailData.author.memberId ? (
               <Kebab onClick={handleKebabClick} width={35} height={35} className={cn("kebabBtn")} />
             ) : (
               <div onClick={handleSirenClick} className={cn("sirenBtn")}>
@@ -252,7 +233,7 @@ function Main(data: any) {
                 page.content.map((comment: CommentProps) => (
                   <Comment
                     type="taker"
-                    authorId={data.data.author.memberId}
+                    authorId={postDetailData.author.memberId}
                     postId={id}
                     comment={comment}
                     commentId={comment.commentId}

--- a/src/components/page-layout/helpMeDetailLayout/components/helpMeDetailLayout.tsx
+++ b/src/components/page-layout/helpMeDetailLayout/components/helpMeDetailLayout.tsx
@@ -155,9 +155,9 @@ function Main(data: any) {
         <div className={cn("totalContainer")}>
           <div className={cn("btnMenu")}>
             {isHeartClick ? (
-              <PinkHeart onClick={handleHeartClick} width={35} height={35} className={cn("likeBtn")} />
+              <PinkHeart onClick={handleHeartClick} width={32} height={32} className={cn("likeBtn")} />
             ) : (
-              <Heart onClick={handleHeartClick} width={37} height={37} className={cn("likeBtn")} />
+              <Heart onClick={handleHeartClick} width={32} height={32} className={cn("likeBtn")} />
             )}
             {userData?.memberId === data.data.author.memberId ? (
               <Kebab onClick={handleKebabClick} width={35} height={35} className={cn("kebabBtn")} />

--- a/src/components/page-layout/helpMeLayout/components/helpMeLayout.module.scss
+++ b/src/components/page-layout/helpMeLayout/components/helpMeLayout.module.scss
@@ -51,3 +51,9 @@
 .button:hover .arrow {
   fill: $taker;
 }
+
+.heart {
+  position: absolute;
+  top: 1rem;
+  right: 2rem;
+}

--- a/src/components/page-layout/helpMeLayout/components/helpMeLayout.tsx
+++ b/src/components/page-layout/helpMeLayout/components/helpMeLayout.tsx
@@ -9,7 +9,8 @@ import { useRouter } from "next/router";
 import Filter from "@/components/common/Filter/Filter";
 import getPaginationItems from "@/components/common/Pagenation/apis/getHelpMeList";
 import Pagination from "@/components/common/Pagenation/Pagenation";
-import { Post, PostHeart } from "@/components/common/Post/Post";
+import { Post } from "@/components/common/Post/Post";
+import { PostHeart } from "@/components/common/Post/PostHeart/PostHeart";
 import styles from "@/components/page-layout/helpMeLayout/components/helpMeLayout.module.scss";
 import { ROUTE } from "@/constants/route";
 import RegisterArrow from "@/icons/send_arrow.svg";
@@ -137,6 +138,7 @@ export default function HelpMeLayout() {
                 queryKey={["helpMePostList", `${page}`, disabilityType, assistanceType, postStatus]}
                 id={post.id}
                 isLiked={post.isLiked}
+                style={cn("heart")}
               />
             </Post>
           ))}

--- a/src/components/page-layout/helpMeRegisterLayout/components/helpMeRegisterLayout.module.scss
+++ b/src/components/page-layout/helpMeRegisterLayout/components/helpMeRegisterLayout.module.scss
@@ -6,7 +6,7 @@
 .box {
   @include flexSort(column, null, center, 5rem);
   border: 0.1rem solid black;
-  width: 100rem;
+  width: 90rem;
   border-radius: 1rem;
   padding: 5rem 0;
 }

--- a/src/components/page-layout/helpYouDetailLayout/components/helpYouDetailLayout.module.scss
+++ b/src/components/page-layout/helpYouDetailLayout/components/helpYouDetailLayout.module.scss
@@ -31,7 +31,7 @@
   position: relative;
 }
 
-.likeBtn,
+.heart,
 .kebabBtn,
 .sirenBtn {
   @include flexSort(column, null, center, 0.2rem);

--- a/src/components/page-layout/helpYouDetailLayout/components/helpYouDetailLayout.tsx
+++ b/src/components/page-layout/helpYouDetailLayout/components/helpYouDetailLayout.tsx
@@ -155,9 +155,9 @@ function Main(data: any) {
         <div className={cn("totalContainer")}>
           <div className={cn("btnMenu")}>
             {isHeartClick ? (
-              <PinkHeart onClick={handleHeartClick} width={35} height={35} className={cn("likeBtn")} />
+              <PinkHeart onClick={handleHeartClick} width={32} height={32} className={cn("likeBtn")} />
             ) : (
-              <Heart onClick={handleHeartClick} width={37} height={37} className={cn("likeBtn")} />
+              <Heart onClick={handleHeartClick} width={32} height={32} className={cn("likeBtn")} />
             )}
             {userData?.memberId === data.data.author.memberId ? (
               <Kebab onClick={handleKebabClick} width={35} height={35} className={cn("kebabBtn")} />

--- a/src/components/page-layout/helpYouDetailLayout/components/helpYouDetailLayout.tsx
+++ b/src/components/page-layout/helpYouDetailLayout/components/helpYouDetailLayout.tsx
@@ -13,6 +13,7 @@ import getLogIn from "@/components/common/Header/apis/getLogIn";
 import Loader from "@/components/common/Loader/Loader";
 import Modal from "@/components/common/Modal/Modal";
 import postLikes from "@/components/common/Post/apis/postLikes";
+import { PostDetailHeart } from "@/components/common/Post/PostHeart/PostHeart";
 import ReportForm from "@/components/common/ReportForm/ReportForm";
 import openToast from "@/components/common/Toast/features/openToast";
 import styles from "@/components/page-layout/helpYouDetailLayout/components/helpYouDetailLayout.module.scss";
@@ -50,24 +51,15 @@ interface CommentProps {
 
 export default function HelpYouDetailLayout() {
   const router = useRouter();
-  const { id: pageId } = router.query;
-
-  const { data, isPending } = useQuery({
-    queryKey: ["giverDetail", pageId],
-    queryFn: () => getGiverDetail(pageId as string),
-    enabled: !!pageId,
-  });
-
-  if (isPending) {
-    return;
-  } else return <Main data={data} />;
-}
-
-function Main(data: any) {
-  const router = useRouter();
-
-  const { id: pageId } = router.query;
   const queryClient = useQueryClient();
+
+  const { id: pageId } = router.query;
+
+  const [isReportOpen, setIsReportOpen] = useState(false);
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [isHeartClick, setIsHeartClick] = useState(false);
+  const [isKebabClick, setIsKebabClick] = useState(false);
+  const [isStateClick, setIsStateClick] = useState(false);
 
   const { data: userData } = useQuery({
     queryKey: ["userLogIn"],
@@ -88,10 +80,19 @@ function Main(data: any) {
     enabled: !!pageId,
   });
 
+  const {
+    data: postDetailData,
+    isPending,
+    isError,
+  } = useQuery({
+    queryKey: ["giverPostDetail", pageId],
+    queryFn: () => getGiverDetail(pageId as string),
+    enabled: !!pageId,
+  });
+
   const deletePostMutation = useMutation({
     mutationFn: (id: number) => deletePost(id),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["giverDetail", pageId] });
       router.push(ROUTE.HELP_YOU);
       openToast("success", "성공적으로 삭제되었습니다.");
     },
@@ -105,28 +106,17 @@ function Main(data: any) {
     deletePostMutation.mutate(id);
   };
 
-  const { mutate } = useMutation({
-    mutationFn: () => postLikes(id),
-  });
+  if (isPending) return <>...로딩</>;
 
-  const handleHeartClick = () => {
-    setIsHeartClick((prev: boolean) => !prev);
-    mutate();
-  };
+  if (isError) return <>에러</>;
 
-  const { nickname, memberId, disabilityType, gender, profileImageUrl, age } = data.data.author;
+  const { nickname, disabilityType, gender, profileImageUrl, age } = postDetailData.author;
 
-  const { district, id, title, content, createdAt, isLiked, assistance, schedule } = data.data.post;
+  const { district, id, title, content, createdAt, isLiked, assistance, schedule } = postDetailData.post;
 
   const { assistanceType, assistanceStartTime, assistanceEndTime } = assistance;
 
   const { scheduleType, startDate, endDate, scheduleDetails } = schedule;
-
-  const [isReportOpen, setIsReportOpen] = useState(false);
-  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
-  const [isHeartClick, setIsHeartClick] = useState(false);
-  const [isKebabClick, setIsKebabClick] = useState(false);
-  const [isStateClick, setIsStateClick] = useState(false);
 
   const handleKebabClick = () => {
     setIsKebabClick((prev) => !prev);
@@ -137,10 +127,6 @@ function Main(data: any) {
   const handleSirenClick = () => {
     setIsReportOpen(true);
   };
-
-  useEffect(() => {
-    setIsHeartClick(isLiked);
-  }, [data, isLiked]);
 
   const commentMemIds: Array<number> =
     commentData?.pages.flatMap((page) => page.content.map((comment: CommentProps) => comment.author.memberId)) || [];
@@ -154,12 +140,13 @@ function Main(data: any) {
         </header>
         <div className={cn("totalContainer")}>
           <div className={cn("btnMenu")}>
-            {isHeartClick ? (
-              <PinkHeart onClick={handleHeartClick} width={32} height={32} className={cn("likeBtn")} />
-            ) : (
-              <Heart onClick={handleHeartClick} width={32} height={32} className={cn("likeBtn")} />
-            )}
-            {userData?.memberId === data.data.author.memberId ? (
+            <PostDetailHeart
+              style={cn("heart")}
+              id={id}
+              isLiked={isLiked}
+              queryKey={["giverPostDetail", `${pageId}`]}
+            />
+            {userData?.memberId === postDetailData.author.memberId ? (
               <Kebab onClick={handleKebabClick} width={35} height={35} className={cn("kebabBtn")} />
             ) : (
               <div onClick={handleSirenClick} className={cn("sirenBtn")}>
@@ -252,7 +239,7 @@ function Main(data: any) {
                 page.content.map((comment: CommentProps) => (
                   <Comment
                     type="giver"
-                    authorId={data.data.author.memberId}
+                    authorId={postDetailData.author.memberId}
                     postId={id}
                     comment={comment}
                     commentId={comment.commentId}

--- a/src/components/page-layout/helpYouLayout/components/helpYouLayout.module.scss
+++ b/src/components/page-layout/helpYouLayout/components/helpYouLayout.module.scss
@@ -51,3 +51,9 @@
 .button:hover .arrow {
   fill: $giver;
 }
+
+.heart {
+  position: absolute;
+  top: 1rem;
+  right: 2rem;
+}

--- a/src/components/page-layout/helpYouLayout/components/helpYouLayout.tsx
+++ b/src/components/page-layout/helpYouLayout/components/helpYouLayout.tsx
@@ -9,7 +9,8 @@ import { useRouter } from "next/router";
 import Filter from "@/components/common/Filter/Filter";
 import getPaginationItems from "@/components/common/Pagenation/apis/getHelpMeList";
 import Pagination from "@/components/common/Pagenation/Pagenation";
-import { Post, PostHeart } from "@/components/common/Post/Post";
+import { Post } from "@/components/common/Post/Post";
+import { PostHeart } from "@/components/common/Post/PostHeart/PostHeart";
 import styles from "@/components/page-layout/helpYouLayout/components/helpYouLayout.module.scss";
 import { ROUTE } from "@/constants/route";
 import RegisterArrow from "@/icons/send_arrow.svg";
@@ -130,6 +131,7 @@ export default function HelpYouLayout() {
                 queryKey={["helpYouPostList", `${page}`, disabilityType, assistanceType, postStatus]}
                 id={post.id}
                 isLiked={post.isLiked}
+                style={cn("heart")}
               />
             </Post>
           ))}

--- a/src/components/page-layout/helpYouRegisterLayout/components/helpYouRegisterLayout.module.scss
+++ b/src/components/page-layout/helpYouRegisterLayout/components/helpYouRegisterLayout.module.scss
@@ -6,7 +6,7 @@
 .box {
   @include flexSort(column, null, center, 5rem);
   border: 0.1rem solid black;
-  width: 100rem;
+  width: 90rem;
   border-radius: 1rem;
   padding: 5rem 0;
 }
@@ -166,11 +166,11 @@
   border: 0.1rem solid #9d9d9d;
 
   &.active {
-    color: #4885FE;
-    border: 0.1rem solid #4885FE;
+    color: #4885fe;
+    border: 0.1rem solid #4885fe;
 
     .arrow {
-      fill: #4885FE;
+      fill: #4885fe;
     }
   }
 }


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약

- 모든 좋아요 기능에 낙관적 업데이트 적용
- 게시글 컴포넌트에서 제목이 2줄이상 넘어가면 ...으로 처리

## 참고 사항

PostHeart 컴포넌트로 모든 좋아요 기능을 처리할려고 했는데 쿼리마다 가지고 있는 값(getQueryData)이 달라서 게시글 상세 페이지에서 사용할 컴포넌트를 만들었습니다.

## 관련 이슈

close #158 

## 체크리스트

- [x] 코드가 제대로 작동하는지 확인
- [x] 빌드를 통과하였는지 확인
